### PR TITLE
downgrade package @quenty/loader to 10.2.0 to fix error

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
         "@quenty/steputils": "^3.4.0",
         "@quenty/table": "^3.5.0",
         "@quenty/uiobjectutils": "^6.3.0"
+    },
+    "override": {
+        "@quenty/loader": "10.2.0",
     }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "@quenty/color3utils": "^11.3.0",
         "@quenty/fzy": "^5.3.0",
         "@quenty/instanceutils": "^13.3.0",
-        "@quenty/loader": "^10.3.0",
+        "@quenty/loader": "10.2.0",
         "@quenty/maid": "^3.2.0",
         "@quenty/math": "^2.7.0",
         "@quenty/observablecollection": "^12.3.0",


### PR DESCRIPTION
![image](https://github.com/unrooot/draw-visualizer/assets/10260415/cc8d89e9-7d49-469f-9d8e-9394cef3fc95)
I got this error when i loaded the plugin into studio but managed to fix it by commenting out the check.

https://github.com/Quenty/NevermoreEngine/blob/a9256cab3584bea4bd32c327d00b9a52f2a3ec95/src/loader/src/LoaderLink/LoaderLink.lua#L26

Downgrading Loader to 10.2.0 before the check was added fixed the issue for me.

https://github.com/Quenty/NevermoreEngine/blame/7f4d4f9cd4a6602af8daaf04983bb349dafc7e95/src/loader/src/LoaderLink/LoaderLink.lua